### PR TITLE
Update Podfile,Using CDN instead of GIT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ install:
         ;;
       "ios")
         npm install
+        gem install cocoapods --no-rdoc --no-ri --no-document --quiet
         cd ios && pod install --repo-update
         ;;
     esac

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,4 +1,4 @@
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://cdn.cocoapods.org/'
 platform :ios, '9.0'
 #inhibit_all_warnings!
 


### PR DESCRIPTION
Using CDN instead of GIT, the cocoapods version needs to be more than 1.7.4